### PR TITLE
update pt.json and add state_stop

### DIFF
--- a/custom_components/smartthingswasher/strings.json
+++ b/custom_components/smartthingswasher/strings.json
@@ -162,6 +162,9 @@
       "state_start_cavity_01": {
         "name": "Second cavity state start"
       },
+      "state_stop": {
+        "name": "State Stop"
+      },      
       "state_stop_cavity_01": {
         "name": "Second cavity state stop"
       }

--- a/custom_components/smartthingswasher/translations/en.json
+++ b/custom_components/smartthingswasher/translations/en.json
@@ -162,6 +162,9 @@
       "state_start_later": {
         "name": "State start later"
       },
+      "state_stop": {
+        "name": "State Stop"
+      },      
       "state_stop_cavity_01": {
         "name": "Second cavity state stop"
       }

--- a/custom_components/smartthingswasher/translations/pt.json
+++ b/custom_components/smartthingswasher/translations/pt.json
@@ -162,6 +162,9 @@
       "state_start_later": {
         "name": "Iniciar mais tarde"
       },
+      "state_stop": {
+        "name": "Parar superior"
+      },      
       "state_stop_cavity_01": {
         "name": "Parar inferior"
       }
@@ -564,6 +567,7 @@
           "autocook": "Cozedura automática",
           "bake": "Cozedura (Bake)",
           "bottom": "Inferior",
+          "bottom_convection": "Convecção inferior",
           "bottom_heat": "Calor inferior",
           "bottom_heat_plus_convection": "Calor inferior + Convecção",
           "broil": "Grelhar (Broil)",
@@ -602,6 +606,7 @@
           "steam_cook": "Cozinhar a vapor",
           "steam_roast": "Assar a vapor",
           "strong_steam": "Vapor forte",
+          "top_convection": "Convecção superior",
           "top_heat_plus_convection": "Calor superior + Convecção",
           "warming": "Aquecimento"
         }
@@ -613,6 +618,7 @@
           "autocook": "Cozedura automática",
           "bake": "Cozedura (Bake)",
           "bottom": "Inferior",
+          "bottom_convection": "Convecção inferior",
           "bottom_heat": "Calor inferior",
           "bottom_heat_plus_convection": "Calor inferior + Convecção",
           "broil": "Grelhar (Broil)",
@@ -651,6 +657,7 @@
           "steam_cook": "Cozinhar a vapor",
           "steam_roast": "Assar a vapor",
           "strong_steam": "Vapor forte",
+          "top_convection": "Convecção superior",
           "top_heat_plus_convection": "Calor superior + Convecção",
           "warming": "Aquecimento"
         }
@@ -822,7 +829,7 @@
         }
       },
       "completion_time": {
-        "name": "Tempo de conclusão"
+        "name": "Tempo de conclusão superior"
       },
       "cooktop_operating_state": {
         "name": "Estado de funcionamento",
@@ -1086,7 +1093,7 @@
         }
       },
       "oven_operation_progress_cavity_01": {
-        "name": "Progresso de operação inferior"
+        "name": "Progresso inferior"
       },
       "oven_operation_time_cavity_01": {
         "name": "Tempo de funcionamento inferior"


### PR DESCRIPTION
I updated the pt.json file and added state_stop to fix the problem that was appearing in the controls; instead of State Stop, the identity name was appearing, which in my case was "forno" (oven).